### PR TITLE
Cannot Dual license GOFL with MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ This project is a security-enhanced fork of [Hasty Server](https://github.com/In
 
 ## License
 
-MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under GOFL (Global Opensource softwares Free License) - see the [LICENSE](LICENSE.md)


### PR DESCRIPTION
The GOFL (Global Open Source Software Free License) cannot be dual-licensed with the MIT License due to conflicting terms. The GOFL imposes specific requirements for attribution, modifications, and redistribution, whereas the MIT License is more permissive and lacks such obligations. As a result, the two licenses are incompatible and cannot be used simultaneously for the same project